### PR TITLE
Update readme with nodejs requirement

### DIFF
--- a/examples/simple-nodejs/README.md
+++ b/examples/simple-nodejs/README.md
@@ -6,6 +6,12 @@ Overview
 
 a demonstration of how to connect to Compass and receive events using a Node.js script; no user interface.
 
+Requirements
+------------
+The Compass library makes use of at least ES2017. The mimimum version of NodeJS that [supports](https://stackoverflow.com/a/40421941/1294864)
+this is `7.0`. Version `6.8.1` also supports it, but is considered unstable and is locked behind
+the `--harmony` flag.
+
 Usage
 ---------
 - Switch to the `examples/simple-nodejs` directory.


### PR DESCRIPTION
NodeJS version 6 does not support the `Object.values` syntax. 6.8.1 does support it,
but is locked behind the `--harmony` flag. NodeJS 7 does support this syntax.

See https://stackoverflow.com/a/40421941/1294864

Not sure if you guys want me to provide solutions as well or if the link is enough? I think it can be inferred that upgrading to > NodeJS 6 is preferred in any case.