### PR TITLE
Improve reconnect

### DIFF
--- a/examples/queues/client.js
+++ b/examples/queues/client.js
@@ -135,6 +135,8 @@ function addQueue(queue) {
 function handleQueueEvent(event) {
 
     let queue = event.emitter;
+    if (!queue) return;
+
     let elem = getQueueElement(queue);
 
     switch (event.eventType) {

--- a/examples/simple-webpack/src/index.js
+++ b/examples/simple-webpack/src/index.js
@@ -30,6 +30,8 @@ promise.then(function () {
 
     // Listen to the userList
     conn.model.usersObservable.subscribe(event => {
+        if (!event.emitter) return;     //reconnect event
+
         console.log(`User ${event.emitter.name} (${event.emitter.id}) event: ${event.eventType}`);
         if (event.eventType === Compass.EventType.PropertyChanged) {
             logPropertyChanged(event);
@@ -38,6 +40,8 @@ promise.then(function () {
 
     // Listen to the queue-list
     conn.model.queuesObservable.subscribe(event => {
+        if (!event.emitter) return;     //reconnect event
+
         console.log(`Queue ${event.emitter.name} (${event.emitter.id}) event: ${event.eventType}`);
         if (event.eventType === Compass.EventType.PropertyChanged) {
             logPropertyChanged(event);
@@ -46,6 +50,8 @@ promise.then(function () {
 
     // Listen to the call-list
     conn.model.callsObservable.subscribe(event => {
+        if (!event.emitter) return;     //reconnect event
+
         console.log(`Call ${event.emitter.id} event: ${event.eventType}`);
         switch (event.eventType) {
             case Compass.EventType.Changed:

--- a/examples/simple/client.js
+++ b/examples/simple/client.js
@@ -27,6 +27,8 @@ promise.then(function () {
 
     // Listen to the userList
     conn.model.usersObservable.subscribe(event => {
+        if (!event.emitter) return; // reconnect events
+
         console.log(`User ${event.emitter.name} (${event.emitter.id}) event: ${event.eventType}`);
         if (event.eventType === compass.EventType.PropertyChanged) {
             logPropertyChanged(event);
@@ -35,6 +37,8 @@ promise.then(function () {
 
     // Listen to the queue-list
     conn.model.queuesObservable.subscribe(event => {
+        if (!event.emitter) return; // reconnect events
+
         console.log(`Queue ${event.emitter.name} (${event.emitter.id}) event: ${event.eventType}`);
         if (event.eventType === compass.EventType.PropertyChanged) {
             logPropertyChanged(event);
@@ -43,6 +47,8 @@ promise.then(function () {
 
     // Listen to the call-list
     conn.model.callsObservable.subscribe(event => {
+        if (!event.emitter) return; // reconnect events
+
         console.log(`Call ${event.emitter.id} event: ${event.eventType}`);
         switch (event.eventType) {
             case compass.EventType.Changed:

--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -132,6 +132,8 @@ export class Connection {
     public close() {
         this._closed = true;
         this._autoReconnectHandler.stop();
+        // we'll get a warning in the console;
+        // https://github.com/strophe/strophejs/issues/291
         this.stropheConnection.disconnect();
         this.stropheConnection.reset();
     }
@@ -144,11 +146,8 @@ export class Connection {
      *
      */
     public disconnect() {
-        this._closed = true;
-        this._autoReconnectHandler.stop();
-        // we'll get a warning in the console;
-        // https://github.com/strophe/strophejs/issues/291
-        this.stropheConnection.disconnect();
+        this.close();
+        // this completes the rx subscriptions
         this.model.clear();
     }
 


### PR DESCRIPTION
In case the Websocket connection is lost, we can actively reconnect instead of waiting for the 30s ping timeout.

This would happen when one Compass webserver is turned off. Nginx will close all TCP connections.

Also made the examples reconnect-proof.

To test:
- Open simple client; use debug loglevel.
- Stop nginx; you'll see active reconnect kick in.
- With all nginx'es running, firewall the connected instance (ie. in `/etc/ferm/ferm.conf`, add `proto tcp dport 443 DROP;` *above* the `mod state` lines). The reconnect timer will make sure the client reconnects to the other nginx.
