### PR TITLE
Add version discovery

### DIFF
--- a/examples/simple-nodejs/client.js
+++ b/examples/simple-nodejs/client.js
@@ -23,7 +23,10 @@ const promise = conn.connect(config.jid, config.password);
 // We are connected and all data-models have been retrieved.
 promise.then(function () {
     console.log("Connected!");
-    process.exit(0);
+    conn.rest.getApiVersion().then(v => {
+        console.log('Found API version', v)
+        process.exit(0);
+    });
 });
 
 promise.catch(function(e) {

--- a/src/RestApi.ts
+++ b/src/RestApi.ts
@@ -106,9 +106,7 @@ export class RestApi {
      * @returns {Promise<any>} - Returns a Promise that resolves with the answer from the rest-api in a js object, or rejects if an error occurs.
      */
     public doRequest(url: string, method: string, data: any): Promise<any> {
-        // determine version to use, if not yet determined, and then request
-        const versionPromise = this._contentType ? Promise.resolve() : this.determineApiVersion();
-        return versionPromise.then(() => this.doRequestInternal(url, method, data));
+        return this.determineApiVersion().then(() => this.doRequestInternal(url, method, data));
     }
 
     private doRequestInternal(url: string, method: string, data: any): Promise<any> {
@@ -140,7 +138,13 @@ export class RestApi {
      * Determine the Compass version we're talking to.
      * When completed, {@link _contentType} and {@link _user} are filled.
      */
-    private async determineApiVersion() {
+    private async determineApiVersion(): Promise<any> {
+
+        if (this._contentType) {
+            // already determined!
+            return;
+        }
+
         for (const version of CONTENT_TYPES) {
             this._contentType = version;
             try {

--- a/src/RestApi.ts
+++ b/src/RestApi.ts
@@ -138,7 +138,7 @@ export class RestApi {
 
     /**
      * Determine the Compass version we're talking to.
-     * When completed, `this._user` is filled.
+     * When completed, {@link _contentType} and {@link _user} are filled.
      */
     private async determineApiVersion() {
         for (const version of CONTENT_TYPES) {
@@ -148,6 +148,7 @@ export class RestApi {
                 // Found acceptable version; return.
                 return;
             } catch (error) {
+                this._contentType = null;
                 if (error.status === 406) {
                     // HTTP not acceptable; try other version
                 } else {


### PR DESCRIPTION
With the first REST request, the library will auto select the right Compass API version to communicate with. It will try versions in decreasing order, by calling the `/user` endpoint.

`getMyUser` is changed to make use of this fact.

When we add v3, this will be useful:
- If talking to a Compass with v3 api, new features like wrapup can be used
- If talking to a Compass with v2 api, the library will automatically go back to v2 content types

Tested:
- that this works with a Compass v2 api, even if you include v3 in the list of content types
- that `getMyUser` works as the first rest call
- that `getMyUser` will return the cached user if it's not the first rest call

Requirement for #30
